### PR TITLE
Update platform.yaml

### DIFF
--- a/fern/apis/platform/platform.yaml
+++ b/fern/apis/platform/platform.yaml
@@ -527,6 +527,8 @@ paths:
                   format: uuid
                 ipv4:
                   type: string
+                netmask:
+                  type: integer
                 port:
                   type: integer
                 is_active:


### PR DESCRIPTION
netmask missing from sipgateway api spec