### PR TITLE
Update retell.mdx to remove 'sip' protocol when adding Retell phone #

### DIFF
--- a/fern/docs/pages/tutorials/retell.mdx
+++ b/fern/docs/pages/tutorials/retell.mdx
@@ -92,7 +92,7 @@ In the Retell Dashboard, select "Phone Numbers" and click the plus sign.
 In the dropdown select "Connect to your number via SIP trunking".
 
 - Add the phone number in E.164 format (ie leading + followed by country code)
-- For termination URI enter a URI with the 'sip' scheme and the DNS of your sip realm in jambonz (you can find that under the Account tab), e.g. 'sip:mydomain.sip.jambonz.cloud'
+- For termination URI enter the DNS of your sip realm in jambonz (you can find that under the Account tab), e.g. 'mydomain.sip.jambonz.cloud'
 - For sip trunk username and password enter the username and password you created above on jambonz.
 
 After creating the phone number, associate it with the Retell agent you want to use.


### PR DESCRIPTION
Changes documentation to align with current Retell interface where the sip scheme is no longer accepted.