### PR TITLE
Ws docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -208,6 +208,42 @@ navigation:
           - callControl:
             - page: Overview
               path: ./docs/pages/ws_api/overview.mdx
+            - page: session:new
+              path: ./docs/pages/ws_api/session-new.mdx
+            - page: session:redirect
+              path: ./docs/pages/ws_api/session-redirect.mdx
+            - page: session:reconnect
+              path: ./docs/pages/ws_api/session-reconnect.mdx
+            - page: call:status
+              path: ./docs/pages/ws_api/call-status.mdx
+            - page: verb:hook
+              path: ./docs/pages/ws_api/verb-hook.mdx
+            - page: verb:status
+              path: ./docs/pages/ws_api/verb-status.mdx
+            - page: llm:event
+              path: ./docs/pages/ws_api/llm-event.mdx
+            - page: llm:tool-call
+              path: ./docs/pages/ws_api/llm-tool-call.mdx
+            - page: tts:tokens-result
+              path: ./docs/pages/ws_api/tts-tokens-result.mdx
+            - page: tts:streaming-event
+              path: ./docs/pages/ws_api/tts-streaming-event.mdx
+            - page: dial:confirm
+              path: ./docs/pages/ws_api/dial-confirm.mdx
+            - page: ack
+              path: ./docs/pages/ws_api/ack.mdx
+            - page: command
+              path: ./docs/pages/ws_api/command.mdx
+            - page: llm:tool-output
+              path: ./docs/pages/ws_api/llm-tool-output.mdx
+            - page: llm:update
+              path: ./docs/pages/ws_api/llm-update.mdx
+            - page: tts:tokens
+              path: ./docs/pages/ws_api/tts-tokens.mdx
+            - page: tts:flush
+              path: ./docs/pages/ws_api/tts-flush.mdx
+            - page: tts:clear
+              path: ./docs/pages/ws_api/tts-clear.mdx
   - tab: sdks
     layout: 
       - page: SDKs

--- a/fern/docs/pages/ws_api/ack.mdx
+++ b/fern/docs/pages/ws_api/ack.mdx
@@ -24,9 +24,3 @@ An `ack` message is sent by the websocket server to jambonz in response to a `se
   ]
 }
 ```
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/jambonz-error">Prev: jambonz:error</a>
-<a href="/docs/ws/command">Next: command</a>
-</p>

--- a/fern/docs/pages/ws_api/call-status.mdx
+++ b/fern/docs/pages/ws_api/call-status.mdx
@@ -47,9 +47,3 @@ A `call:status` message is sent by jambonz to the websocket server any time the 
   }
 }
 ```
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/session-reconnect">Prev: session:reconnect</a>
-<a href="/docs/ws/verb-hook">Next: verb:hook</a>
-</p>

--- a/fern/docs/pages/ws_api/command.mdx
+++ b/fern/docs/pages/ws_api/command.mdx
@@ -47,8 +47,3 @@ The `command` property must be one of the values shown below.
   ]
 }
 ```
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/ack">Prev: ack</a>
-</p>

--- a/fern/docs/pages/ws_api/dial-confirm.mdx
+++ b/fern/docs/pages/ws_api/dial-confirm.mdx
@@ -5,9 +5,3 @@ title: dial:confirm
 >> jambonz => websocket server
 
 A `dial:confirm` message is sent by jambonz to the websocket server when dial verb is using a confirm hook to interact with the called party before connecting them to the caller.  The application should respond with an array of verbs that will drive that interaction.
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/jambonz-error.mdx
+++ b/fern/docs/pages/ws_api/jambonz-error.mdx
@@ -28,8 +28,4 @@ A `jambonz:error` message is sent by jambonz to the websocket server if jambonz 
 }
 ```
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/verb-status">Prev: verb:status</a>
-<a href="/docs/ws/ack">Next: ack</a>
-</p>
+

--- a/fern/docs/pages/ws_api/llm-event.mdx
+++ b/fern/docs/pages/ws_api/llm-event.mdx
@@ -6,8 +6,3 @@ title: llm:event
 
 An `llm:event` message is sent by jambonz to the application when an LLM being managed by jambonz (i.e., the [llm verb](docs/webhooks/llm/)) has generated any sort of event.  The payload will include the data provided by the LLM.
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/llm-tool-call.mdx
+++ b/fern/docs/pages/ws_api/llm-tool-call.mdx
@@ -11,8 +11,3 @@ The payload will include the following properties:
 - call_id: an identifier that must be returned in the `llm:tool-output` method sent by the application to return function call results, and
 - args: an object containing the parameters provided as part of the function call
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/llm-tool-output.mdx
+++ b/fern/docs/pages/ws_api/llm-tool-output.mdx
@@ -10,8 +10,3 @@ The payload must include:
 - tool_call_id: the value of call_id in the "llm:tool-call" message
 - data: an object containing the results of the function
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/llm-update.mdx
+++ b/fern/docs/pages/ws_api/llm-update.mdx
@@ -9,8 +9,3 @@ An `llm:tool-update` message is sent by the application to jambonz in response t
 The message has a `data` payload that contains the information that should be used to update the llm.
 
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/overview.mdx
+++ b/fern/docs/pages/ws_api/overview.mdx
@@ -74,10 +74,3 @@ The following messages can be sent from your application back to jambonz
 |tts:tokens|sent when the application wants to stream text, e.g. from an LLM being managed on the application side.  This may be called multiple times as the LLM itself streams tokens|
 |tts:flush|sent periodically during TTS streaming when the application wants to cause audio to be generated|
 |tts:clear|sent during TTS streaming when the application wants to discard any queued audio and tokens, e.g. to handle an interruption|
-
-
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/session-new">Next: session:new</a>
-</p>

--- a/fern/docs/pages/ws_api/session-new.mdx
+++ b/fern/docs/pages/ws_api/session-new.mdx
@@ -72,8 +72,3 @@ The websocket server must reply reply to a `session:new` message with an [ack](/
 }
 ```
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/session-reconnect.mdx
+++ b/fern/docs/pages/ws_api/session-reconnect.mdx
@@ -70,9 +70,3 @@ A `session:reconnect` message is sent by jambonz to the websocket server when th
 	}
 }
 ```
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/session-redirect">Prev: session:redirect</a>
-<a href="/docs/ws/call-status">Next: call:status</a>
-</p>

--- a/fern/docs/pages/ws_api/session-redirect.mdx
+++ b/fern/docs/pages/ws_api/session-redirect.mdx
@@ -49,8 +49,3 @@ A `session:redirect` message is sent by jambonz to the websocket server when a c
 }
 ```
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/session-new">Prev: session:new</a>
-<a href="/docs/ws/session-reconnect">Next: session:reconnect</a>
-</p>

--- a/fern/docs/pages/ws_api/tts-clear.mdx
+++ b/fern/docs/pages/ws_api/tts-clear.mdx
@@ -8,8 +8,3 @@ An `tts:clear` message is sent by the application to jambonz to cause all audio 
 
 This message has no other properties.
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/tts-flush.mdx
+++ b/fern/docs/pages/ws_api/tts-flush.mdx
@@ -28,10 +28,3 @@ The snippet of example code below, written using [@jambonz/node-client-ws](https
     }
 
 ```
-
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/tts-streaming-event.mdx
+++ b/fern/docs/pages/ws_api/tts-streaming-event.mdx
@@ -13,8 +13,4 @@ The message shall contain an event_type field with one of the following values:
 - stream_paused: the token buffer is full and the application should discontinue sending tokens
 - stream_resumed: the application may resume sending tokens
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>
+

--- a/fern/docs/pages/ws_api/tts-tokens-result.mdx
+++ b/fern/docs/pages/ws_api/tts-tokens-result.mdx
@@ -14,9 +14,3 @@ The message shall contain:
 
 The most common reason for a 'failed' response is if the token buffer maintained by jambonz for this conversation is full.  In that case the reason will be 'full' and the application should stop sending any further tts:tokens messages until a [tts:streaming-event](docs/ws/tts-streaming-event) message is received indicating that streaming of TTS tokens can resume.
 
-
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/tts-tokens.mdx
+++ b/fern/docs/pages/ws_api/tts-tokens.mdx
@@ -18,8 +18,3 @@ The intent is that as the application receives a stream of tokens from an LLM th
 
 The application will receive a [tts:tokens-result](docs/ws/tts-tokens-result) message in response to each tts:tokens message it sends.  
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/overview">Prev: overview</a>
-<a href="/docs/ws/session-redirect">Next: session:redirect</a>
-</p>

--- a/fern/docs/pages/ws_api/verb-hook.mdx
+++ b/fern/docs/pages/ws_api/verb-hook.mdx
@@ -58,8 +58,4 @@ A `verb:hook` message is sent by jambonz to the websocket server when an action 
 }
 ```
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/call-status">Prev: call:status</a>
-<a href="/docs/ws/verb-status">Next: verb:status</a>
-</p>
+

--- a/fern/docs/pages/ws_api/verb-status.mdx
+++ b/fern/docs/pages/ws_api/verb-status.mdx
@@ -33,8 +33,3 @@ A `verb:status` message is sent by jambonz to the websocket server when a verb h
 ```
 
 
-<p class="flex">
-<span>&nbsp;</span>
-<a href="/docs/ws/verb-hook">Prev: verb:hook</a>
-<a href="/docs/ws/jambonz-error">Next: jambonz:error</a>
-</p>


### PR DESCRIPTION
brings over the old websocket reference docs and puts them within the API ref section.

Probabbly needs another pass to tidy up the formatting a bit for the new style but these should be functional