### PR TITLE
docs(self-hosting): add Bare metal / VPS guide for Debian-package install

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -289,14 +289,16 @@ navigation:
             path: ./docs/pages/self-hosting/post-install.mdx
           - page: Setting up WebRTC and SIP TLS
             path: ./docs/pages/self-hosting/wss-siptls.mdx
-      - page: AWS
-        path: ./docs/pages/self-hosting/aws.mdx
-      - page: Azure
-        path: ./docs/pages/self-hosting/azure.mdx
-      - page: GCP
-        path: ./docs/pages/self-hosting/gcp.mdx
-      - page: OCI
-        path: ./docs/pages/self-hosting/oci.mdx
+      - section: Hosting Providers
+        contents:
+          - page: AWS
+            path: ./docs/pages/self-hosting/aws.mdx
+          - page: Azure
+            path: ./docs/pages/self-hosting/azure.mdx
+          - page: GCP
+            path: ./docs/pages/self-hosting/gcp.mdx
+          - page: OCI
+            path: ./docs/pages/self-hosting/oci.mdx
       - page: Bare metal / VPS
         path: ./docs/pages/self-hosting/bare-metal.mdx
       - section: Kubernetes

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -297,6 +297,8 @@ navigation:
         path: ./docs/pages/self-hosting/gcp.mdx
       - page: OCI
         path: ./docs/pages/self-hosting/oci.mdx
+      - page: Bare metal / VPS
+        path: ./docs/pages/self-hosting/bare-metal.mdx
       - section: Kubernetes
         path: ./docs/pages/self-hosting/k8s-overview.mdx
         contents:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -299,8 +299,10 @@ navigation:
             path: ./docs/pages/self-hosting/gcp.mdx
           - page: OCI
             path: ./docs/pages/self-hosting/oci.mdx
-      - page: Bare metal / VPS
-        path: ./docs/pages/self-hosting/bare-metal.mdx
+      - section: Bare metal / VPS
+        contents:
+          - page: Debian package
+            path: ./docs/pages/self-hosting/debian-package.mdx
       - section: Kubernetes
         path: ./docs/pages/self-hosting/k8s-overview.mdx
         contents:

--- a/fern/docs/pages/features/custom-speech-tts.mdx
+++ b/fern/docs/pages/features/custom-speech-tts.mdx
@@ -1,40 +1,199 @@
 # Text-to-speech API
 
-jambonz provides native support for lots of speech recognition vendors, but if you want to integrate with a vendor we don't yet support you can easily do this by writing to our API.  
+jambonz provides native support for many TTS vendors, but if you want to integrate with one we don't yet support you can do it by writing a small server that implements our API.
 
-The TTS API is a simple http-based api.  
+There are two APIs you can implement, depending on whether your vendor supports streaming:
 
-jambonz sends an HTTP POST containing the text to be synthesized and associated properties such as language and voice.  Your server is responsible for implementing the interface to your chosen speech vendor and returning an mp3 file containing the audio.  
+- **Non-streaming HTTP API** — jambonz posts a full text payload to your server and you return a single audio file. Use this when the vendor's API is request/response.
+- **Streaming WebSocket API** — jambonz opens a persistent WebSocket and streams text tokens to your server as they arrive (typically from an LLM); your server streams synthesized audio back. Use this when the vendor supports incremental synthesis (ElevenLabs WebSocket, Cartesia, Rime, etc.) — it dramatically reduces time-to-first-audio for LLM-driven applications.
 
-Want to look at some working code?  Check out [these examples](https://github.com/jambonz/custom-speech-example).
+When you add a custom speech vendor in the jambonz portal you provide an HTTPS URL (for non-streaming) and/or a WebSocket URL (for streaming). You may provide either or both. The same API key is used for both.
 
-## Authentication
+Want working code? Check out [these examples](https://github.com/jambonz/custom-speech-example).
 
-An Authorization header is sent by jambonz on the HTTP request.  The Authorization header contains an api key, e.g.
+## Non-streaming HTTP API
 
-```js
+jambonz sends an HTTP POST containing the text to be synthesized and associated properties such as language and voice. Your server returns the synthesized audio as the response body.
+
+### Authentication
+
+An `Authorization` header is sent on the HTTP request:
+
+```
 Authorization: Bearer <apiKey>
 ```
 
-When you create a custom speech vendor in the jambonz portal you will specify an api key which is then then provided in the Authorization header whenever that custom speech vendor is used in yourj application.
+The API key is the value you provide when you create the custom speech vendor in the jambonz portal.
 
-## Request body attributes
+### Request body attributes
 
-| property | type | description  |
-| ---------|-------------| -----|
-| language | String | ISO language code (e.g. "en-US") |
-| voice | String | Name of voice to use |
-| type | String | "text" or "ssml"|
-| text | String | text to be synthesized (if type=ssml should be enclosed in `<speak>` tags) |
+| Property | Type | Description |
+|---|---|---|
+| `language` | String | ISO language code (e.g. `en-US`) |
+| `voice` | String | Name of the voice to use |
+| `type` | String | `text` or `ssml` |
+| `text` | String | Text to be synthesized. If `type=ssml`, must be enclosed in `<speak>` tags. |
 
-## Response body attributes
+### Response
 
-Your server should return a 200 OK containing a body with the synthesized speech in case of success, or an HTTP error code in case of a failure.  The format of the returned audio must be indicated in the Content-Type header; the following values are allowed:
+Return a `200 OK` containing the synthesized audio in the response body, or an HTTP error code on failure. The audio format is indicated via the `Content-Type` header. Allowed values:
 
-- audio/mpeg (or audio/mp3) - the content should be mp3 audio (this is the preferred format to return)
-- audio/wav (or audio/x-wav) - the content should be linear PCM audio with a wave header
-- audio/l16;rate=8000 - the content should be linear16 audio with 8khz sampling
-- audio/l16;rate=16000 - the content should be linear16 audio with 16khz sampling
-- audio/l16;rate=24000 - the content should be linear16 audio with 24khz sampling
-- audio/l16;rate=32000 - the content should be linear16 audio with 32khz sampling
-- audio/l16;rate=48000 - the content should be linear16 audio with 48khz sampling
+| Content-Type | Format |
+|---|---|
+| `audio/mpeg` or `audio/mp3` | MP3 (preferred) |
+| `audio/wav` or `audio/x-wav` | Linear PCM with a WAVE header |
+| `audio/l16;rate=8000` | Linear16 PCM at 8 kHz |
+| `audio/l16;rate=16000` | Linear16 PCM at 16 kHz |
+| `audio/l16;rate=24000` | Linear16 PCM at 24 kHz |
+| `audio/l16;rate=32000` | Linear16 PCM at 32 kHz |
+| `audio/l16;rate=48000` | Linear16 PCM at 48 kHz |
+
+## Streaming WebSocket API
+
+The streaming API lets jambonz push text to your server incrementally and receive audio back as it's produced — eliminating the wait for a full HTTP response. This is what makes "the LLM and the TTS overlap" possible.
+
+When jambonz needs to synthesize speech, it opens a WebSocket to your server, sends a sequence of text fragments and a flush signal, then keeps the connection open for further synthesis on the same call. Your server is responsible for translating that into whatever wire protocol your TTS vendor uses (ElevenLabs WebSocket, Cartesia, etc.) and streaming the resulting audio back.
+
+### Connection
+
+jambonz connects to:
+
+```
+wss://<your-host>[:port]/<your-path>?voice=<voice>&language=<language>&sampleRate=<rate>
+```
+
+The host, port, and path come from the streaming URL you configured on the custom speech credential. `voice` and `language` are the values from the application that invoked the TTS (the [say](/verbs/verbs/say) verb's `voice` and `language`, or whatever the agent verb resolved). `sampleRate` is the call's media sample rate — typically `8000` for PSTN or `16000` for WebRTC; your server should use this as a target rate (resample if your vendor produces something different).
+
+`ws://` is also supported (set the credential URL with `ws://` instead of `wss://`) for development against localhost.
+
+### Authentication
+
+The WebSocket upgrade request includes:
+
+```
+Authorization: Bearer <apiKey>
+```
+
+`<apiKey>` is the same key configured on the custom speech credential.
+
+### Protocol
+
+After the connection is established, your server must send a `connect` acknowledgement declaring the audio format it will produce. After that, jambonz streams text in and your server streams audio back until either side closes the connection.
+
+#### Server → jambonz: connect acknowledgement
+
+Send this once, right after the WebSocket handshake completes:
+
+```json
+{
+  "type": "connect",
+  "data": {
+    "sample_rate": 16000,
+    "base64_encoding": true
+  }
+}
+```
+
+- `sample_rate` — the sample rate of the PCM audio your server will produce. jambonz resamples to the call's rate if needed.
+- `base64_encoding` — if `true`, your server will send audio as base64-encoded strings inside `data` messages (see below). If `false` (or omitted), your server will send audio as raw binary WebSocket frames. Binary frames are more efficient.
+
+#### jambonz → server: text streaming
+
+Once the `connect` ack is received, jambonz sends one or more `stream` messages with text tokens:
+
+```json
+{"type": "stream", "text": "Hello, "}
+{"type": "stream", "text": "how can I "}
+{"type": "stream", "text": "help you today?"}
+```
+
+Followed by a `flush` to signal the end of an utterance:
+
+```json
+{"type": "flush"}
+```
+
+`flush` is your cue to commit any buffered text to the vendor and finalize the current synthesis. Your server may receive more `stream`/`flush` cycles on the same connection during the call.
+
+When jambonz is done with the session, it sends:
+
+```json
+{"type": "stop"}
+```
+
+…and may then close the WebSocket.
+
+#### Server → jambonz: audio data
+
+For each `flush`, your server should stream the synthesized audio back as it arrives from the underlying vendor. There are two transport options, chosen by your `base64_encoding` setting in the `connect` ack:
+
+**Binary frames (preferred — `base64_encoding: false`)**: send raw L16 PCM audio at the rate you declared in `connect`, as WebSocket binary frames. Send chunks as they arrive — don't wait for the full utterance.
+
+**Base64 JSON (`base64_encoding: true`)**: send each audio chunk as:
+
+```json
+{
+  "type": "data",
+  "data": {
+    "audio": "<base64-encoded L16 PCM>"
+  }
+}
+```
+
+Either way, send audio chunks incrementally as your vendor produces them — that's the point of streaming.
+
+#### Server → jambonz: errors
+
+To report an error mid-stream, send:
+
+```json
+{
+  "type": "data",
+  "data": {
+    "error": "<error message>"
+  }
+}
+```
+
+The error message is logged on the jambonz side. One specific value has special semantics: `"error": "input_timeout_exceeded"` tells jambonz it's safe to reconnect later (most vendors close the socket after a period of inactivity). Use this value if your upstream vendor closes the connection for idleness so jambonz knows the close was expected and can open a fresh socket on the next utterance.
+
+### Audio sample rate handling
+
+jambonz resamples your audio if `sample_rate` in the `connect` ack differs from the call's `sampleRate` query parameter. You can either:
+
+- Match `sampleRate` from the query string (one less resample), or
+- Always produce at your vendor's natural rate (let jambonz resample).
+
+Both are fine; pick whichever simplifies your server.
+
+### Reference flow
+
+A typical session looks like:
+
+```
+jambonz                                  your server                            vendor
+  ─── WS connect (with Authorization) ──>
+                                          ─── auth/connect to vendor ──>
+  <── {"type":"connect","data":{...}} ───
+  ─── {"type":"stream","text":"…"} ───>
+  ─── {"type":"stream","text":"…"} ───>
+                                          ─── tokens to vendor ──>
+  ─── {"type":"flush"} ──────────────>
+                                          ─── flush to vendor ──>
+                                                                                <── audio chunk
+  <── binary PCM frame ──────────────────
+                                                                                <── audio chunk
+  <── binary PCM frame ──────────────────
+                                                                                <── end-of-utterance
+  ─── {"type":"stream","text":"…"} ───>   (next utterance on same socket)
+  …
+  ─── {"type":"stop"} ──────────────>
+  ─── WS close ──────────────────────>
+```
+
+### Tips
+
+- **Keep one upstream connection per WebSocket session.** Don't open a new vendor connection on every `flush` — that defeats the latency win. Buffer text from `stream` messages, commit on `flush`, but reuse the underlying vendor connection across `flush` cycles.
+- **Start sending audio bytes immediately.** Don't wait for the vendor to finish synthesizing the whole utterance before forwarding the first chunk. The first audio frame jambonz receives is what determines time-to-first-byte (logged as `tts_time_to_first_byte_ms`).
+- **Handle the idle-close case.** If your vendor closes the upstream socket after silence, send `"error": "input_timeout_exceeded"` so jambonz reconnects cleanly on the next utterance instead of failing.
+- **Stay within the declared `sample_rate`.** If your vendor's output rate doesn't match what you declared in `connect`, resample on your side or change the `connect` ack — don't send mismatched audio.

--- a/fern/docs/pages/self-hosting/bare-metal.mdx
+++ b/fern/docs/pages/self-hosting/bare-metal.mdx
@@ -1,0 +1,352 @@
+---
+title: Bare metal / VPS
+subtitle: Install jambonz mini on any Debian 12 host using our apt repository.
+---
+
+For bare metal, any VPS provider (Hetzner, Vultr, DigitalOcean, Linode, OVH, on-prem, etc.), or an existing Debian 12 host, jambonz publishes a `.deb` package that installs the whole single-host stack from `apt`. This is the simplest deployment path when you're not on AWS / Azure / GCP / OCI and don't want to use one of the prebuilt images.
+
+<Note>
+This guide installs the **jambonz mini** all-in-one deployment (every component on a single host). Multi-host topologies — separate SBC, feature-server, web, and monitoring tiers — currently still require the cloud-image guides (AWS, Azure, GCP, OCI). Multi-host Debian packages are in development.
+</Note>
+
+## Prerequisites
+
+- Debian 12 (bookworm), amd64
+- `sudo` access
+- At least **4 vCPU**, **8 GB RAM**, **100 GB disk**
+- Public IPv4 address
+- Network rules / firewall configured to allow the ports below
+
+### Required open ports
+
+| Service | Ports |
+|---|---|
+| SIP | `5060/udp`, `5060/tcp`, `5061/tcp`, `8443/tcp` |
+| HTTP / HTTPS | `80/tcp`, `443/tcp` |
+| RTP media | `40000–60000/udp` |
+
+How you open these depends on your provider — security groups on a cloud VPS, an OS-level firewall (`ufw`, `nftables`) on bare metal, or a hardware firewall in front. Consult your provider's documentation.
+
+## Add the apt sources
+
+Four apt sources are required: the jambonz repository itself, plus three upstream sources that ship dependencies Debian doesn't include directly.
+
+```bash
+sudo apt-get update -qq
+sudo apt-get install -y -qq curl ca-certificates gnupg systemd
+
+# 1. jambonz APT source
+sudo install -d /etc/apt/keyrings
+curl -fsSL https://jambonz-debian-packages.s3.us-east-2.amazonaws.com/jambonz.gpg \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/jambonz.gpg
+echo "deb [signed-by=/etc/apt/keyrings/jambonz.gpg] https://jambonz-debian-packages.s3.us-east-2.amazonaws.com/debian bookworm main" \
+  | sudo tee /etc/apt/sources.list.d/jambonz.list
+
+# 2. InfluxData APT source (for telegraf — not in Debian's repos)
+curl -fsSL https://repos.influxdata.com/influxdata-archive.key \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/influxdata.gpg
+echo "deb [signed-by=/etc/apt/keyrings/influxdata.gpg] https://repos.influxdata.com/debian stable main" \
+  | sudo tee /etc/apt/sources.list.d/influxdata.list
+
+# 3. NodeSource APT source (Node 22 — Debian ships 18)
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+
+# 4. Grafana APT source (for the metrics dashboard)
+curl -fsSL https://apt.grafana.com/gpg.key \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/grafana.gpg
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
+  | sudo tee /etc/apt/sources.list.d/grafana.list
+
+sudo apt-get update
+```
+
+## Install jambonz mini
+
+rtpengine includes a kernel module that DKMS will compile on the host, so the matching Linux headers must be installed first:
+
+```bash
+sudo apt-get install -y linux-headers-$(uname -r)
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jambonz-mini
+```
+
+That's it. apt resolves the full dependency tree (jambonz-common, jambonz-monitoring-agent, jambonz-rtpengine, jambonz-rtpengine-dkms, drachtio, jambonz-freeswitch, telegraf, nodejs, MariaDB, Redis, nginx, Grafana).
+
+### What the postinst did
+
+While apt was running, the `jambonz-mini` package's post-install script:
+
+- Generated per-host secrets in `/var/lib/jambonz/secrets.env` (mode `600`)
+- Auto-detected the host's local subnet and wrote it to `/var/lib/jambonz/host.env`
+- Waited for MariaDB to be ready, then created the `jambones` database, ran the schema and seed, and applied any pending migrations
+- Enabled and started the `jambonz-apps.target` systemd target and its child services
+
+On a clean install this completes in a minute or two.
+
+## Verify the install
+
+```bash
+echo "=== mysql admin user ==="
+sudo mysql -e "SELECT user, host FROM mysql.user WHERE user='admin';"
+
+echo "=== schema version ==="
+sudo mysql -e "USE jambones; SELECT version FROM schema_version;"
+
+echo "=== telegraf listening on :8125 ==="
+sudo ss -tnlp '( sport = :8125 )'
+
+echo "=== systemd units ==="
+systemctl --no-pager list-units 'jambonz-*' --all
+
+echo "=== webapp returns HTTP 200 ==="
+curl -sI http://localhost/ | head -1
+
+echo "=== no ECONNREFUSED in recent logs (should be 0) ==="
+sudo journalctl -u 'jambonz-*' -n 200 --no-pager 2>/dev/null | grep -c 'ECONNREFUSED.*8125'
+```
+
+All `jambonz-*` units should be `active (running)`. The webapp should return `HTTP/1.1 200 OK`. The `ECONNREFUSED` count should be `0`.
+
+## First login
+
+Browse to `http://<host-ip>/` (make sure port 80 is open).
+
+Default admin credentials, seeded by the postinst:
+
+- **Email**: `joe@foo.bar`
+- **Password**: `admin`
+
+`force_change` is set on the account, so you'll be required to set a new password on first login.
+
+## Next steps
+
+Before going to production:
+
+- **DNS records and HTTPS** — see the [Post-Install Steps](/self-hosting/overview/post-install) article. It walks through creating the A records (`api.`, `grafana.`, `homer.`, `public-apps.`, `sip.`) and using `certbot` to obtain a TLS certificate for the portal.
+- **WebRTC and SIP TLS** — see [Setting up WebRTC and SIP TLS](/self-hosting/overview/wss-siptls) if you need WSS or SIPS.
+- **Licensing** — obtain a license key as described in the [Licensing](/self-hosting/overview/licensing) article. Free trial licenses are available; extended licenses for non-commercial use and pre-revenue startups can be requested at `support@jambonz.org`.
+
+## The `jambonz` CLI
+
+The `jambonz-common` package ships a `jambonz` command at `/usr/bin/jambonz` for day-2 operations:
+
+| Command | Description |
+|---|---|
+| `sudo jambonz upgrade` | Refresh apt indexes, list which jambonz packages have new versions, prompt for confirmation, run the upgrade, then run `jambonz health`. No-op when there's nothing new. |
+| `jambonz health` | Quick check of every jambonz systemd unit + connectivity to MariaDB, Redis, telegraf, drachtio, and FreeSWITCH. |
+| `jambonz version` | Print the installed package versions (apt + bundled Node apps). |
+| `jambonz status` | Compact `systemctl status` summary across `jambonz-*` units. |
+| `jambonz env <app>` | Print the resolved environment that `<app>` would see (after merging the 4-layer env chain). Useful for debugging config. |
+| `jambonz crash <app>` | Show a bracketed `journalctl` window around the most recent (re)start of `<app>` — the fastest way to look at a crash. |
+
+## Customizing config
+
+Environment variables for the Node apps come from four files, layered in order — later files override earlier ones on conflict:
+
+1. `/etc/jambonz/jambonz.env` — shared, customer-editable config
+2. `/etc/jambonz/<app>.env` — per-app overrides (e.g. `feature-server.env`)
+3. `/var/lib/jambonz/host.env` — per-host runtime (auto-generated; also the right place for terraform/ansible to write)
+4. `/var/lib/jambonz/secrets.env` — generated cluster secrets, mode `600`
+
+### Files you can edit (conffile-protected)
+
+These files are tracked by dpkg. Your edits survive upgrades; if a release ships a new default you'll be prompted (see [Upgrading](#upgrading) below).
+
+| File | Purpose |
+|---|---|
+| `/etc/jambonz/jambonz.env` | Shared env for all Node apps (DB host, Redis host, log level) |
+| `/etc/jambonz/feature-server.env` | feature-server overrides |
+| `/etc/jambonz/api-server.env` | api-server overrides |
+| `/etc/jambonz/inbound.env` | sbc-inbound overrides |
+| `/etc/jambonz/outbound.env` | sbc-outbound overrides |
+| `/etc/jambonz/sbc-call-router.env` | sbc-call-router overrides |
+| `/etc/jambonz/sbc-sip-sidecar.env` | sbc-sip-sidecar overrides |
+| `/etc/jambonz/sbc-rtpengine-sidecar.env` | sbc-rtpengine-sidecar overrides |
+| `/etc/nginx/sites-available/jambonz` | nginx reverse proxy + webapp + SIP trace ingest |
+| `/etc/drachtio/drachtio-5070.conf.xml` | FS-tier drachtio config |
+| `/etc/drachtio.conf.xml` | SBC-tier drachtio config |
+| `/etc/freeswitch/...` | FreeSWITCH config |
+| `/etc/rtpengine/rtpengine.conf` | rtpengine config |
+
+### Files that are generated — do NOT edit
+
+These get rewritten on every upgrade. Edits will be lost. If you need to change a value, edit the *source* env file instead.
+
+| File | Source of truth |
+|---|---|
+| `/etc/default/upload-recordings` | `/var/lib/jambonz/secrets.env` + `/etc/jambonz/jambonz.env` |
+| `/etc/systemd/system/drachtio.service.d/jambonz.conf` | `/etc/jambonz/jambonz.env` |
+| `/etc/systemd/system/drachtio.service.d/jambonz-execstart.conf` | static — systemd-252 workaround |
+| `/etc/systemd/system/drachtio.service.d/homer.conf` | static — HEP wiring |
+| `/etc/systemd/system/freeswitch.service.d/jambonz.conf` | `/etc/jambonz/jambonz.env` |
+| `/etc/systemd/system/grafana-server.service.d/jambonz.conf` | static — port 3010 to avoid collision with feature-server |
+
+After editing any of the conffile-protected files above, apply with:
+
+```bash
+sudo systemctl restart jambonz-apps.target
+```
+
+## Adding custom systemd directives
+
+If you need extra `Environment=` or `ExecStartPre=` directives on a system unit (for example to enable SIP over TLS on drachtio), don't edit the shipped service file or the `jambonz*.conf` drop-ins — both get reset on upgrade. Create your own drop-in whose name does **not** start with `jambonz`:
+
+```bash
+sudo install -d -m 755 /etc/systemd/system/drachtio.service.d
+sudo tee /etc/systemd/system/drachtio.service.d/local.conf >/dev/null <<'EOF'
+[Service]
+ExecStartPre=/usr/local/sbin/setup-tls-cert.sh
+Environment="DRACHTIO_EXTRA_ARGS=--sips-port 5061"
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart drachtio
+```
+
+jambonz upgrades will never touch a drop-in not named `jambonz*.conf`. Your `local.conf` survives every upgrade.
+
+## Upgrading
+
+The simplest path:
+
+```bash
+sudo jambonz upgrade
+```
+
+This refreshes apt indexes, lists which jambonz packages have new versions, asks for confirmation, runs the upgrade, and finishes with a `jambonz health` so you immediately see whether anything came back failing. If there's nothing new, it's a no-op with a clean message.
+
+The equivalent raw apt commands:
+
+```bash
+sudo apt-get update
+sudo apt-get upgrade
+```
+
+Schema migrations run automatically — the `jambonz-mini` postinst detects the existing `schema_version` table, skips the seed, and applies only pending migrations. Existing data is preserved.
+
+### Conffile prompts
+
+If an upgrade ships a new default for a config file under `/etc/` **and** you've edited that file, dpkg will prompt you:
+
+```
+Configuration file '/etc/jambonz/feature-server.env'
+ ==> Modified (by you or by a script) since installation.
+ ==> Package distributor has shipped an updated version.
+   What would you like to do about it?  Your options are:
+    Y or I  : install the package maintainer's version
+    N or O  : keep your currently-installed version
+      D     : show the differences between the versions
+      Z     : start a shell to examine the situation
+ The default action is to keep your current version.
+*** feature-server.env (Y/I/N/O/D/Z) [default=N] ?
+```
+
+The default (`N` — keep your edits) is almost always the right answer for env files. Press **D first** to see what changed — sometimes the new version adds variables worth adopting, in which case keep your file with `N` and add the new variables manually.
+
+<Warning>
+For the two third-party conffiles `/etc/heplify-server.toml` and `/etc/default/pcap-server`, **always** pick `N`. The `jambonz-mini` postinst sed-edits credential lines into those files. Picking `Y` would lose the generated credentials and break the services. If you accidentally pick `Y`, restore with `sudo dpkg-reconfigure jambonz-mini`.
+</Warning>
+
+### Recommended pre-upgrade ritual
+
+For production boxes:
+
+```bash
+# 1. Snapshot the database
+sudo mysqldump --single-transaction --routines --triggers jambones \
+  > /tmp/jambones-$(date +%F).sql
+
+# 2. Capture current versions for rollback reference
+jambonz version > /tmp/versions-before.txt
+
+# 3. Confirm the system is healthy before upgrading
+jambonz health
+
+# 4. Upgrade
+sudo jambonz upgrade
+
+# 5. Confirm health after (jambonz upgrade does this automatically too)
+jambonz health
+```
+
+## Rolling back
+
+If an upgrade breaks something and you need to drop back to a previous version:
+
+```bash
+# Show available versions
+apt-cache madison jambonz-mini
+
+# Pin back to a specific version
+sudo apt-get install --allow-downgrades \
+  jambonz-mini=10.1.5 \
+  jambonz-common=10.1.5
+```
+
+Schema migrations do **not** auto-roll-back — once new tables or columns exist, they persist. That's safe because the migration policy guarantees backward compatibility (no `DROP TABLE`, no new `NOT NULL` columns without defaults), so old code reading a newer schema works correctly. You don't need to restore the database to roll back code.
+
+If you ever do need the schema rolled back, restore MySQL from your pre-upgrade backup *before* downgrading the deb.
+
+## Removing
+
+```bash
+sudo apt-get purge jambonz-mini jambonz-common jambonz-monitoring-agent
+```
+
+`apt-get purge` removes configuration files but **does not** drop the `jambones` database — your data is preserved. For a true reset, drop it manually:
+
+```bash
+sudo mysql -e "DROP DATABASE jambones; DROP USER 'admin'@'%';"
+```
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="A jambonz-* unit shows failed after upgrade">
+    Use `jambonz crash <app>` to see a bracketed `journalctl` window around the most recent restart of the failing app. This is usually faster than scrolling through `journalctl -xe`.
+  </Accordion>
+
+  <Accordion title="MySQL connection errors from a Node app">
+    Confirm `/var/lib/jambonz/secrets.env` has the expected password:
+
+    ```bash
+    sudo grep JAMBONES_MYSQL_PASSWORD /var/lib/jambonz/secrets.env
+    sudo mysql -uroot -e "SELECT user FROM mysql.user WHERE user='admin'\\G"
+    ```
+
+    If the password and the MySQL user are out of sync, re-run `sudo dpkg-reconfigure jambonz-mini` to regenerate.
+  </Accordion>
+
+  <Accordion title="Recording 404s after upgrade">
+    Check the feature-server's recording websocket URL:
+
+    ```bash
+    jambonz env feature-server | grep -i record
+    ```
+
+    `JAMBONZ_RECORD_WS_BASE_URL` should be `ws://127.0.0.1:3017`. Then confirm the recording service is up with `jambonz status` — `upload_recordings` should be `active`.
+  </Accordion>
+
+  <Accordion title="pcap retrieval suddenly returns empty">
+    The drachtio HEP-encapsulation drop-in may have been clobbered. Confirm it still exists:
+
+    ```bash
+    sudo cat /etc/systemd/system/drachtio.service.d/jambonz-execstart.conf
+    ```
+
+    It should include `--homer 127.0.0.1:9060 --homer-id 10`. If missing or different, re-run `sudo dpkg-reconfigure jambonz-mini`.
+  </Accordion>
+
+  <Accordion title="TLS certificate expired">
+    `sudo certbot renew`. Certbot installs a systemd timer that handles renewals automatically — only run this manually if you see "Your certificate has expired" in the portal.
+  </Accordion>
+
+  <Accordion title="Something else is wrong and I don't know where to start">
+    Run `jambonz health` first. It narrows the problem to a specific layer (database, Redis, telegraf, drachtio, FreeSWITCH, or a Node app) much faster than reading logs unaided.
+  </Accordion>
+</AccordionGroup>
+
+## Known limitations
+
+<Warning>
+Multi-host topologies (separate SBC, feature-server, web, and monitoring tiers) are not yet supported via apt. Only the single-host `jambonz-mini` package is currently published. If you need a clustered deployment, use the [AWS](/self-hosting/aws), [Azure](/self-hosting/azure), [GCP](/self-hosting/gcp), [OCI](/self-hosting/oci), or [Kubernetes](/self-hosting/kubernetes) guides instead.
+</Warning>

--- a/fern/docs/pages/self-hosting/bare-metal.mdx
+++ b/fern/docs/pages/self-hosting/bare-metal.mdx
@@ -118,14 +118,25 @@ sudo -E JAMBONES_PORTAL_DOMAIN=portal.example.com \
 
 apt resolves the full dependency tree (jambonz-common, jambonz-monitoring-agent, jambonz-rtpengine, jambonz-rtpengine-dkms, drachtio, jambonz-freeswitch, telegraf, nodejs, MariaDB, Redis, nginx, Grafana).
 
+<Warning>
+On some cloud instances, `linux-headers-cloud-amd64` will install headers for a **newer** kernel than the one currently running (because the running kernel image is older than what's in the repos). DKMS can build the rtpengine module only for kernels whose headers it has, so it builds against the newer one. The postinst detects this and prints a **REBOOT RECOMMENDED** message at the end of the install. Reboot to use the newer kernel, after which rtpengine will use kernel-mode forwarding. Until you reboot, rtpengine works in userspace-only mode (functional but less efficient).
+</Warning>
+
 ### What the postinst did
 
-While apt was running, the `jambonz-mini` package's post-install script:
+While apt was running, the `jambonz-common` and `jambonz-mini` post-install scripts:
 
-- Generated per-host secrets in `/var/lib/jambonz/secrets.env` (mode `600`)
+- Created the `jambonz` system user with passwordless sudo and copied the cloud-init user's SSH `authorized_keys` so you can `ssh jambonz@<host>` with the same keypair
+- Generated per-host secrets in `/var/lib/jambonz/secrets.env` (mode `600` — JWT signing key, MySQL password, Homer/heplify credentials, recording auth)
 - Auto-detected the host's local subnet and wrote it to `/var/lib/jambonz/host.env`
-- Waited for MariaDB to be ready, then created the `jambones` database, ran the schema and seed, and applied any pending migrations
-- Enabled and started the `jambonz-apps.target` systemd target and its child services
+- Waited for MariaDB, then created the `jambones` database, ran the schema and seed, and applied any pending migrations
+- Wrote systemd drop-ins for drachtio and FreeSWITCH so they pick up the generated DB/Redis credentials
+- Set up PostgreSQL plus the HEP / SIP-capture stack (`heplify-server` + `pcap-server`) with a generated `heplify` role and the `homer_data` / `homer_config` databases
+- Configured InfluxDB and Grafana (moved Grafana to port 3010 to avoid colliding with the Node apps on 3000)
+- Configured the `upload_recordings` C++ daemon with the matching `ENCRYPTION_SECRET` so it can decrypt bucket credentials
+- Checked the rtpengine DKMS kernel module against the running kernel — building it if headers are available, or queueing a **REBOOT RECOMMENDED** warning if a newer kernel was installed
+- Wrote the nginx config (vhosts for portal / api / grafana if a portal domain was supplied, otherwise a catch-all on the default server) and reloaded nginx
+- Enabled and started the `jambonz-apps.target` systemd target and its child services, plus drachtio, FreeSWITCH, rtpengine, heplify-server, pcap-server, InfluxDB, and Grafana
 
 On a clean install this completes in a minute or two.
 
@@ -157,7 +168,7 @@ All `jambonz-*` units should be `active (running)`. The webapp should return `HT
 
 Before logging in for the first time, complete these steps:
 
-- **DNS records and HTTPS** — see the [Post-Install Steps](/self-hosting/overview/post-install) article. It walks through creating the A records (`api.`, `grafana.`, `public-apps.`, `sip.`) and using `certbot` to obtain a TLS certificate for the portal.
+- **DNS records and HTTPS** — see the [Post-Install Steps](/self-hosting/overview/post-install) article. It walks through creating the A records (`api.` and `grafana.`) and using `certbot` to obtain a TLS certificate for the portal.
 - **WebRTC and SIP TLS** — see [Setting up WebRTC and SIP TLS](/self-hosting/overview/wss-siptls) if you need WSS or SIPS.
 - **Licensing** — obtain a license key as described in the [Licensing](/self-hosting/overview/licensing) article. Free trial licenses are available; extended licenses for non-commercial use and pre-revenue startups can be requested at `support@jambonz.org`.
 
@@ -170,9 +181,19 @@ Browse to your portal's DNS name (e.g. `https://my-domain.example.com`) and log 
 
 You'll be required to set a new password on first login.
 
+## Logging in as the `jambonz` user
+
+The install creates a `jambonz` system user with passwordless `sudo` and copies the cloud-init user's SSH keys into `/home/jambonz/.ssh/authorized_keys`. Day-2 operations are intended to be performed as this user — not as `root`, `admin`, `ubuntu`, or `ec2-user`.
+
+```bash
+ssh jambonz@<this-host>
+```
+
+You should see this user mentioned in the final lines of the install output. Once logged in, the `jambonz` CLI is on `$PATH` and `sudo` works without a password prompt.
+
 ## The `jambonz` CLI
 
-The `jambonz-common` package ships a `jambonz` command at `/usr/bin/jambonz` for day-2 operations:
+The `jambonz-common` package ships a `jambonz` command at `/usr/bin/jambonz` for day-2 operations. Run it as the `jambonz` user:
 
 | Command | Description |
 |---|---|
@@ -230,7 +251,6 @@ These files are tracked by dpkg. Your edits survive upgrades; if a release ships
 | `/etc/jambonz/sbc-call-router.env` | sbc-call-router overrides |
 | `/etc/jambonz/sbc-sip-sidecar.env` | sbc-sip-sidecar overrides |
 | `/etc/jambonz/sbc-rtpengine-sidecar.env` | sbc-rtpengine-sidecar overrides |
-| `/etc/nginx/sites-available/jambonz` | nginx reverse proxy + webapp + SIP trace ingest |
 | `/etc/drachtio/drachtio-5070.conf.xml` | FS-tier drachtio config |
 | `/etc/drachtio.conf.xml` | SBC-tier drachtio config |
 | `/etc/freeswitch/...` | FreeSWITCH config |
@@ -242,12 +262,15 @@ These get rewritten on every upgrade. Edits will be lost. If you need to change 
 
 | File | Source of truth |
 |---|---|
+| `/etc/nginx/sites-available/jambonz` | written by `jambonz-configure-domain` — to change vhosts, re-run that script |
 | `/etc/default/upload-recordings` | `/var/lib/jambonz/secrets.env` + `/etc/jambonz/jambonz.env` |
 | `/etc/systemd/system/drachtio.service.d/jambonz.conf` | `/etc/jambonz/jambonz.env` |
-| `/etc/systemd/system/drachtio.service.d/jambonz-execstart.conf` | static — systemd-252 workaround |
-| `/etc/systemd/system/drachtio.service.d/homer.conf` | static — HEP wiring |
+| `/etc/systemd/system/drachtio.service.d/jambonz-execstart.conf` | static — systemd-252 workaround + HEP wiring |
+| `/etc/systemd/system/drachtio-feature-server.service.d/jambonz.conf` | `/etc/jambonz/jambonz.env` |
+| `/etc/default/drachtio-feature-server` | static — FS-tier port + config overrides |
 | `/etc/systemd/system/freeswitch.service.d/jambonz.conf` | `/etc/jambonz/jambonz.env` |
 | `/etc/systemd/system/grafana-server.service.d/jambonz.conf` | static — port 3010 to avoid collision with feature-server |
+| `/etc/sudoers.d/jambonz` | written by `jambonz-common.postinst` — passwordless sudo for the `jambonz` user |
 
 After editing any of the conffile-protected files above, apply with:
 

--- a/fern/docs/pages/self-hosting/bare-metal.mdx
+++ b/fern/docs/pages/self-hosting/bare-metal.mdx
@@ -60,16 +60,63 @@ echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stab
 sudo apt-get update
 ```
 
+## Choose your portal DNS name
+
+<Warning>
+Before installing, you need to decide on the DNS name you'll use for the jambonz portal (for example `portal.example.com`). This is **required**: jambonz uses the portal domain for nginx routing, certbot TLS, and your software license is keyed to it.
+</Warning>
+
+Pick a hostname you control DNS for. The installer will configure nginx for that name and these related subdomains:
+
+- `portal.example.com` — the admin webapp
+- `api.portal.example.com` — the REST API
+- `grafana.portal.example.com` — metrics dashboards
+
+You should create A records for all of the above pointing at your host's public IP. You can do this before *or* after the install, but it must be done before you obtain TLS certificates with certbot. See [Post-Install Steps](/self-hosting/overview/post-install) for the DNS record list.
+
+### Supplying the domain to the installer
+
+You have three options:
+
+1. **Inline on the install command** (recommended / simplest):
+
+   ```bash
+   sudo -E JAMBONES_PORTAL_DOMAIN=portal.example.com \
+     DEBIAN_FRONTEND=noninteractive apt-get install -y jambonz-mini
+   ```
+
+   The `-E` flag preserves the environment variable through `sudo`.
+
+2. **Pre-supply via `/etc/jambonz/install.conf`** (good for terraform / ansible / cloud-init):
+
+   ```bash
+   sudo install -d /etc/jambonz
+   echo "JAMBONES_PORTAL_DOMAIN=portal.example.com" | sudo tee /etc/jambonz/install.conf
+   ```
+
+   Then run the normal install — the postinst will read `install.conf` automatically.
+
+3. **Configure it after installing**, if you forgot:
+
+   ```bash
+   sudo jambonz-configure-domain portal.example.com
+   ```
+
+   This idempotent helper updates the nginx server name, writes `JAMBONES_PORTAL_DOMAIN` to `/var/lib/jambonz/host.env`, and is the same logic the postinst would have run with the env var set.
+
+If you install without specifying a domain, the install completes but the postinst prints a `NO PORTAL DOMAIN configured` warning — license validation will not succeed until you run `jambonz-configure-domain`.
+
 ## Install jambonz mini
 
-rtpengine includes a kernel module that DKMS will compile on the host, so the matching Linux headers must be installed first:
+rtpengine includes a kernel module that DKMS will compile on the host, so the matching Linux headers must be installed first. Then run the install with your portal domain:
 
 ```bash
-sudo apt-get install -y linux-headers-$(uname -r)
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jambonz-mini
+sudo apt-get install -y linux-headers-cloud-amd64 || sudo apt-get install -y linux-headers-$(uname -r)
+sudo -E JAMBONES_PORTAL_DOMAIN=portal.example.com \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y jambonz-mini
 ```
 
-That's it. apt resolves the full dependency tree (jambonz-common, jambonz-monitoring-agent, jambonz-rtpengine, jambonz-rtpengine-dkms, drachtio, jambonz-freeswitch, telegraf, nodejs, MariaDB, Redis, nginx, Grafana).
+apt resolves the full dependency tree (jambonz-common, jambonz-monitoring-agent, jambonz-rtpengine, jambonz-rtpengine-dkms, drachtio, jambonz-freeswitch, telegraf, nodejs, MariaDB, Redis, nginx, Grafana).
 
 ### What the postinst did
 

--- a/fern/docs/pages/self-hosting/bare-metal.mdx
+++ b/fern/docs/pages/self-hosting/bare-metal.mdx
@@ -106,24 +106,22 @@ sudo journalctl -u 'jambonz-*' -n 200 --no-pager 2>/dev/null | grep -c 'ECONNREF
 
 All `jambonz-*` units should be `active (running)`. The webapp should return `HTTP/1.1 200 OK`. The `ECONNREFUSED` count should be `0`.
 
-## First login
+## Post-install steps
 
-Browse to `http://<host-ip>/` (make sure port 80 is open).
+Before logging in for the first time, complete these steps:
 
-Default admin credentials, seeded by the postinst:
-
-- **Email**: `joe@foo.bar`
-- **Password**: `admin`
-
-`force_change` is set on the account, so you'll be required to set a new password on first login.
-
-## Next steps
-
-Before going to production:
-
-- **DNS records and HTTPS** — see the [Post-Install Steps](/self-hosting/overview/post-install) article. It walks through creating the A records (`api.`, `grafana.`, `homer.`, `public-apps.`, `sip.`) and using `certbot` to obtain a TLS certificate for the portal.
+- **DNS records and HTTPS** — see the [Post-Install Steps](/self-hosting/overview/post-install) article. It walks through creating the A records (`api.`, `grafana.`, `public-apps.`, `sip.`) and using `certbot` to obtain a TLS certificate for the portal.
 - **WebRTC and SIP TLS** — see [Setting up WebRTC and SIP TLS](/self-hosting/overview/wss-siptls) if you need WSS or SIPS.
 - **Licensing** — obtain a license key as described in the [Licensing](/self-hosting/overview/licensing) article. Free trial licenses are available; extended licenses for non-commercial use and pre-revenue startups can be requested at `support@jambonz.org`.
+
+## First login
+
+Browse to your portal's DNS name (e.g. `https://my-domain.example.com`) and log in with:
+
+- **Username**: `admin`
+- **Password**: `admin`
+
+You'll be required to set a new password on first login.
 
 ## The `jambonz` CLI
 
@@ -132,11 +130,35 @@ The `jambonz-common` package ships a `jambonz` command at `/usr/bin/jambonz` for
 | Command | Description |
 |---|---|
 | `sudo jambonz upgrade` | Refresh apt indexes, list which jambonz packages have new versions, prompt for confirmation, run the upgrade, then run `jambonz health`. No-op when there's nothing new. |
-| `jambonz health` | Quick check of every jambonz systemd unit + connectivity to MariaDB, Redis, telegraf, drachtio, and FreeSWITCH. |
+| `jambonz health` | Stack-level check: every jambonz Node app, drachtio, FreeSWITCH, rtpengine, upload-recordings, pcap-server, heplify-server, MariaDB, Redis, PostgreSQL, and nginx — are they all active and listening on the right ports? |
 | `jambonz version` | Print the installed package versions (apt + bundled Node apps). |
-| `jambonz status` | Compact `systemctl status` summary across `jambonz-*` units. |
+| `jambonz status` (alias `ls`) | List jambonz Node apps with state, PID, restart count, last-start age, and memory usage. Flags apps that have restarted. |
+| `jambonz logs [-f] [<app>]` | Tail logs. With no `<app>`, streams the merged journal of every jambonz Node app. With `<app>`, scoped to that unit. `-f` follows in real time. |
+| `jambonz show <app>` | Detailed `systemctl status` block + the last 30 journal lines + the listening ports owned by that app's PID. |
 | `jambonz env <app>` | Print the resolved environment that `<app>` would see (after merging the 4-layer env chain). Useful for debugging config. |
-| `jambonz crash <app>` | Show a bracketed `journalctl` window around the most recent (re)start of `<app>` — the fastest way to look at a crash. |
+| `jambonz crash <app>` | Show a bracketed `journalctl` window — 30s before through 60s after the most recent (re)start of `<app>`. The fastest way to look at a crash. |
+| `jambonz start\|stop\|restart <app\|all>` | Lifecycle control for one app or every jambonz Node app at once. Auto-elevates via `sudo`. |
+
+### Tailing logs
+
+Common usage:
+
+```bash
+# Stream every jambonz Node app's journal, live
+jambonz logs -f
+
+# Same, scoped to one app (short form — "feature-server" → jambonz-feature-server)
+jambonz logs -f feature-server
+
+# Print recent logs and exit (no -f)
+jambonz logs api-server
+
+# For non-Node services, pass the full unit name
+jambonz logs -f drachtio
+jambonz logs -f freeswitch
+```
+
+App-name resolution is forgiving: short forms like `feature-server`, `api-server`, `inbound`, `outbound` are expanded to their `jambonz-*` unit names. For drachtio, FreeSWITCH, and rtpengine — which aren't part of the jambonz Node-app set — pass the full unit name.
 
 ## Customizing config
 

--- a/fern/docs/pages/self-hosting/debian-package.mdx
+++ b/fern/docs/pages/self-hosting/debian-package.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bare metal / VPS
+title: Debian package
 subtitle: Install jambonz mini on any Debian 12 host using our apt repository.
 ---
 
@@ -102,7 +102,13 @@ You have three options:
    sudo jambonz-configure-domain portal.example.com
    ```
 
-   This idempotent helper updates the nginx server name, writes `JAMBONES_PORTAL_DOMAIN` to `/var/lib/jambonz/host.env`, and is the same logic the postinst would have run with the env var set.
+   This idempotent helper:
+   - Writes the nginx config (vhosts for `portal.example.com`, `api.portal.example.com`, `grafana.portal.example.com`) and reloads nginx
+   - Writes `JAMBONES_PORTAL_DOMAIN` to `/var/lib/jambonz/host.env`
+   - Updates the `system_information` row in MySQL (required for drachtio's license validation)
+   - Restarts drachtio, freeswitch, and the jambonz Node services so they pick up the new domain
+
+   Safe to re-run any number of times. Same logic the postinst runs with the env var set.
 
 If you install without specifying a domain, the install completes but the postinst prints a `NO PORTAL DOMAIN configured` warning — license validation will not succeed until you run `jambonz-configure-domain`.
 

--- a/fern/docs/pages/self-hosting/overview.mdx
+++ b/fern/docs/pages/self-hosting/overview.mdx
@@ -6,8 +6,7 @@ subtitle: Running jambonz on your own infrastructure
 This section provides information on how to deploy jambonz on your own hosting provider or data center.
 
 <Note>
-Currently, we are providing support for self-hosting on AWS, but check back soon as we will be adding 
-documentation and devops scripts for many other hosting environments soon.
+jambonz can be self-hosted on AWS, Azure, GCP, OCI, Kubernetes (EKS, AKS, GKE, SKS), and on bare metal or any VPS via our [Debian package install path](/self-hosting/bare-metal). See the per-environment guides in the left sidebar.
 </Note>
 
 ## Choosing a Deployment Size

--- a/fern/docs/pages/self-hosting/overview.mdx
+++ b/fern/docs/pages/self-hosting/overview.mdx
@@ -6,7 +6,7 @@ subtitle: Running jambonz on your own infrastructure
 This section provides information on how to deploy jambonz on your own hosting provider or data center.
 
 <Note>
-jambonz can be self-hosted on AWS, Azure, GCP, OCI, Kubernetes (EKS, AKS, GKE, SKS), and on bare metal or any VPS via our [Debian package install path](/self-hosting/bare-metal). See the per-environment guides in the left sidebar.
+jambonz can be self-hosted on AWS, Azure, GCP, OCI, Kubernetes (EKS, AKS, GKE, SKS), and on bare metal or any VPS via our [Debian package install path](/self-hosting/debian-package). See the per-environment guides in the left sidebar.
 </Note>
 
 ## Choosing a Deployment Size

--- a/fern/docs/pages/self-hosting/post-install.mdx
+++ b/fern/docs/pages/self-hosting/post-install.mdx
@@ -21,28 +21,39 @@ Using the DNS name that you specified during deployment (e.g. `my-domain.example
 - `my-domain.example.com`
 - `api.my-domain.example.com`
 - `grafana.my-domain.example.com`
-- `public-apps.my-domain.example.com`
+- `public-apps.my-domain.example.com` *(cloud-image deployments only)*
 
 **Pointing to SbcServerIP:**
-- `sip.my-domain.example.com`
+- `sip.my-domain.example.com` *(cloud-image deployments only)*
+
+<Note>
+**bare-metal / Debian package installs** only require the first three records (`my-domain`, `api.`, `grafana.`). The `public-apps.` and `sip.` subdomains are used by the cloud-image (AMI) deployments and aren't proxied through nginx in the Debian package — SIP traffic on a mini install reaches drachtio directly at the host's public IP, and the `public-apps` demo content is served from the main portal vhost.
+</Note>
 
 # Enable HTTPS for the portal
 
-SSH into the Web/Monitoring server and install TLS certificates:
+SSH into the Web/Monitoring server as the `jambonz` user and install TLS certificates:
 
 ```bash
-#ssh into the server
 ssh -i <your-ssh-keypair> jambonz@<WebServerIP>
 
- # generate TLS certs
-sudo certbot --nginx
-
-# edit the VITE_API_BASE_URL param to use https
-cd ~/apps/webapp && vi .env 
-
-# restart the webapp under https
-npm run build && pm2 restart webapp 
+# Generate TLS certs for the portal vhosts
+sudo certbot --nginx \
+  -d my-domain.example.com \
+  -d api.my-domain.example.com \
+  -d grafana.my-domain.example.com
 ```
+
+<Note>
+**Cloud-image (AMI) deployments only** — after running certbot, edit `~/apps/webapp/.env` to set `VITE_API_BASE_URL` to the `https://` URL, then rebuild and restart the webapp:
+
+```bash
+cd ~/apps/webapp && vi .env
+npm run build && pm2 restart webapp
+```
+
+This step is **not** required for the bare-metal / Debian package install. The webapp in the Debian package falls back to `window.location.protocol` at runtime, so it picks up HTTPS automatically once certbot finishes.
+</Note>
 
 # First time login
 

--- a/fern/docs/pages/self-hosting/post-install.mdx
+++ b/fern/docs/pages/self-hosting/post-install.mdx
@@ -21,7 +21,6 @@ Using the DNS name that you specified during deployment (e.g. `my-domain.example
 - `my-domain.example.com`
 - `api.my-domain.example.com`
 - `grafana.my-domain.example.com`
-- `homer.my-domain.example.com`
 - `public-apps.my-domain.example.com`
 
 **Pointing to SbcServerIP:**


### PR DESCRIPTION
## Summary

- New self-hosting article: **Bare metal / VPS** (`fern/docs/pages/self-hosting/bare-metal.mdx`) covering the apt-based `jambonz-mini` install path on any Debian 12 host
- Slots into the Self-Hosting tab between **OCI** and **Kubernetes** in `docs.yml`
- Updates `self-hosting/overview.mdx` to drop the stale "AWS only / check back soon" note and list every currently supported environment

## What the new page covers

1. When to use this path (bare metal, VPS providers, on-prem) and what's in/out of scope
2. Prerequisites: Debian 12 amd64, 4 vCPU / 8 GB RAM / 100 GB disk, public IPv4, and the full required-ports table (SIP `5060/udp+tcp`, `5061/tcp`, `8443/tcp`; HTTP/S `80/tcp`, `443/tcp`; RTP `40000–60000/udp`)
3. Adding the four apt sources (jambonz, InfluxData, NodeSource, Grafana)
4. Install commands (incl. `linux-headers` for rtpengine DKMS)
5. What the postinst did — secrets, subnet detection, schema/seed/migrations, systemd target
6. Verify block and first-login defaults
7. Cross-links to existing **Post-Install Steps**, **WSS/SIP-TLS**, and **Licensing** pages (no duplication)
8. `jambonz` CLI reference (`upgrade`, `health`, `version`, `status`, `env`, `crash`)
9. Customizing config — the 4-layer env-file chain with two tables (conffile-protected vs generated)
10. Adding custom systemd directives via non-`jambonz*` drop-ins
11. Upgrading — `sudo jambonz upgrade`, conffile prompt guidance, pre-upgrade ritual
12. Rolling back via `--allow-downgrades`, with the schema-forward-only caveat
13. Removing — `apt-get purge` and optional manual DB drop
14. Troubleshooting accordion (six common symptoms)
15. Known-limitations warning — single-host mini only currently

## Source material

The article is derived from (paraphrased, not copied) the internal customer-facing docs in the packer repo:
- `selfhosting/packer/packaging/INSTALL.md`
- `selfhosting/packer/packaging/UPGRADING.md`

`BUILDING.md` was deliberately excluded — it's developer-internal.

## Test plan

- [ ] `fern docs dev` renders the new page at `/self-hosting/bare-metal` with no MDX errors
- [ ] Nav entry appears in the left sidebar between **OCI** and **Kubernetes**
- [ ] Cross-links resolve (no 404s):
  - [ ] `/self-hosting/overview/post-install`
  - [ ] `/self-hosting/overview/wss-siptls`
  - [ ] `/self-hosting/overview/licensing`
  - [ ] `/self-hosting/aws`, `/self-hosting/azure`, `/self-hosting/gcp`, `/self-hosting/oci`
  - [ ] `/self-hosting/kubernetes` (the section link in the known-limitations warning — may need to point at a specific K8s page if the section slug doesn't resolve)
- [ ] Updated `<Note>` on the overview page renders cleanly and its link to `/self-hosting/bare-metal` works
- [ ] Code blocks copy paste-able (no leading prompts, no broken backticks)
- [ ] Troubleshooting accordion expands/collapses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
