### PR TITLE
chore: upgrade Fern from 3.37.3 to 5.44.4

### DIFF
--- a/fern/docs/pages/features/voice-agents.mdx
+++ b/fern/docs/pages/features/voice-agents.mdx
@@ -142,8 +142,12 @@ For AWS Bedrock, pass `accessKeyId`, `secretAccessKey`, and `region` in the `aut
 
 ## Turn Detection
 
-The `turnDetection` property controls how the agent verb decides the user has finished speaking. 
+The `turnDetection` property controls how the agent verb decides the user has finished speaking.
 We currently support only two modes — STT-based detection and [Krisp's turn detection model](https://lab.krisp.ai/products/turn-taking).
+
+<Note title="Self-Hosted Licensing">
+Krisp turn detection requires a separate Krisp API license on self-hosted deployments. See [Krisp configuration](/self-hosting/krisp) for details. This does not apply to jambonz.cloud customers.
+</Note>
 
 ### STT-based detection (default)
 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "jambonz",
-  "version": "3.37.3"
+  "version": "5.44.4"
 }


### PR DESCRIPTION
## Summary

- Upgrade Fern from 3.37.3 to 5.44.4

## Test plan

- [ ] Verify docs build successfully with `fern docs dev`
- [ ] Check preview deployment for any rendering issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)