### PR TITLE
docs(murf): document Murf.ai as a streaming TTS vendor

### DIFF
--- a/fern/docs/pages/features/tts-streaming.mdx
+++ b/fern/docs/pages/features/tts-streaming.mdx
@@ -27,6 +27,7 @@ Finally, as of release 0.9.3 we support the following TTS vendors for streaming:
 - Cartesia
 - Rimelabs
 - Google
+- Murf
 
 We are adding additional vendors all the time, so check back with us if you are looking for support from a different vendor.
 

--- a/fern/docs/pages/verbs/synthesizer.mdx
+++ b/fern/docs/pages/verbs/synthesizer.mdx
@@ -134,6 +134,21 @@ Example: "Hi. \<200> I'd love to have a conversation with you." adds a 200ms pau
     </ParamField>
   </Accordion>
 
+  <Accordion title="murf">
+    <ParamField path="style" type="string" required={false}>
+      The speaking style for the voice, e.g. `Conversational` (see [Murf docs](https://murf.ai/api/docs/text-to-speech/web-sockets))
+    </ParamField>
+    <ParamField path="rate" type="number" required={false}>
+      Adjusts the speaking rate. (see [Murf docs](https://murf.ai/api/docs/text-to-speech/web-sockets))
+    </ParamField>
+    <ParamField path="pitch" type="number" required={false}>
+      Adjusts the voice pitch. (see [Murf docs](https://murf.ai/api/docs/text-to-speech/web-sockets))
+    </ParamField>
+    <ParamField path="variation" type="number" required={false}>
+      Controls the amount of variation in pace, pitch and emphasis. (see [Murf docs](https://murf.ai/api/docs/text-to-speech/web-sockets))
+    </ParamField>
+  </Accordion>
+
   <Accordion title="verbio">
     <ParamField path="engine_version" type="string" required={false}>
       The engine version to use. (see [Verbio docs](https://doc.speechcenter.verbio.com/#tag/Speech-To-Text/Available-languages-and-features))


### PR DESCRIPTION
- add Murf to the supported streaming TTS vendors list in tts-streaming.mdx
- add a murf accordion to the synthesizer verb with its vendor-specific options (style, rate, pitch, variation)
- https://github.com/jambonz/feature-server/issues/118