### PR TITLE
docs(tts): document Inworld streaming, word timestamps and options

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -122,6 +122,10 @@ navigation:
             path: ./docs/pages/features/custom-speech-stt.mdx
           - page: Custom TTS providers
             path: ./docs/pages/features/custom-speech-tts.mdx
+          - section: TTS Vendor Settings
+            contents:
+              - page: Inworld
+                path: ./docs/pages/features/tts-vendors/inworld.mdx
           - page: Answering machine detection
             path: ./docs/pages/features/answering-machine-detection.mdx
           - page: Conferencing "coach" mode

--- a/fern/docs/pages/features/tts-vendors/inworld.mdx
+++ b/fern/docs/pages/features/tts-vendors/inworld.mdx
@@ -1,0 +1,72 @@
+---
+title: Inworld
+subtitle: Pitch, speaking rate and temperature controls for Inworld TTS.
+---
+
+Inworld tuning is passed in `synthesizer.options`. Audio shaping lives under a nested `audioConfig` object, matching Inworld's own API.
+
+```json
+{
+  "verb": "say",
+  "text": "Thanks for calling, how can I help you today?",
+  "synthesizer": {
+    "vendor": "inworld",
+    "language": "en",
+    "voice": "Ashley",
+    "options": {
+      "temperature": 0.8,
+      "audioConfig": {
+        "pitch": 0.0,
+        "speakingRate": 1.0
+      }
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField path="temperature" type="number" required={false}>
+  Sampling temperature. Defaults to `0.8`. Lower values give a more consistent, predictable read; higher values more variation between renders of the same text.
+</ParamField>
+
+### audioConfig
+
+<ParamField path="audioConfig.speakingRate" type="number" required={false}>
+  Speaking rate multiplier. Defaults to `1.0`. Values above `1.0` are faster, below are slower.
+</ParamField>
+
+<ParamField path="audioConfig.pitch" type="number" required={false}>
+  Pitch adjustment. Defaults to `0.0`, the voice's natural pitch.
+</ParamField>
+
+<ParamField path="audioConfig.sampleRateHertz" type="number" required={false}>
+  Output sample rate. jambonz already requests the rate that matches the call's codec, so leave this unset unless you have a specific reason — overriding it forces a resample.
+</ParamField>
+
+<ParamField path="audioConfig.bitRate" type="number" required={false}>
+  Output bit rate.
+</ParamField>
+
+## Streaming
+
+Inworld supports [TTS streaming](/guides/features/tts-streaming), including
+token-by-token streaming for `say` with `stream: true` and for the `agent` verb,
+where text is spoken as your LLM produces it.
+
+`audioConfig.pitch` applies to non-streaming synthesis only; Inworld's streaming
+API does not accept it.
+
+## Word timestamps
+
+On `inworld-tts-1.5-mini`, `inworld-tts-1.5-max` and `inworld-tts-2`, Inworld
+returns word-level timing along with the audio. jambonz uses it to track how much
+of a response the caller actually heard, which powers
+[`trackTtsPlayout`](/guides/features/tts-streaming) and lets a barge-in trim the
+conversation history to the words spoken before the interruption. No configuration
+is needed beyond enabling that feature — jambonz requests the timing itself.
+
+`inworld-tts-1` and `inworld-tts-1-max` return no timing, so playout tracking is
+unavailable on them. Both are marked deprecated in the portal and are no longer
+offered for new speech credentials; existing credentials that use them keep
+working, and you can still select them if you need to.


### PR DESCRIPTION
Inworld now supports token streaming (`say stream:true`, `agent`) and returns word-level timestamps on the 1.5 models and `inworld-tts-2`, which drive `trackTtsPlayout` and barge-in transcript trimming.

Adds the Inworld TTS vendor page covering:

- `synthesizer.options` — `temperature` and the nested `audioConfig`
- that `audioConfig.pitch` applies to non-streaming synthesis only (it is not in Inworld's streaming schema)
- which models report word timestamps, and what jambonz uses them for
- the deprecation of `inworld-tts-1` / `-1-max`

## Note on the nav

The page lives at `features/tts-vendors/inworld.mdx`, matching where the pending Gradium docs PR (#151) puts its vendor pages. That section does not exist on `main` yet, so this PR creates it containing Inworld only. When #151 lands, the conflict is confined to the `TTS Vendor Settings` contents list in `docs.yml` — the page path itself already agrees.

Documents jambonz/mediajam#94 and jambonz/feature-server#165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)